### PR TITLE
Remove os.path, use Path to fix url mapping issue

### DIFF
--- a/usgs_stream_mapper/metadata.txt
+++ b/usgs_stream_mapper/metadata.txt
@@ -2,7 +2,7 @@
 name=USGS Stream Mapper
 qgisMinimumVersion=3.0
 description=Display upstream/downstream tributaries and basins using USGS NWIS site numbers
-version=0.1
+version=0.2
 author=Austin Raney
 email=aaraney@crimson.ua.edu
 

--- a/usgs_stream_mapper/usgs_stream_mapper.py
+++ b/usgs_stream_mapper/usgs_stream_mapper.py
@@ -37,6 +37,7 @@ from qgis.PyQt.QtWidgets import QAction
 from .resources import *
 # Import the code for the dialog
 from .usgs_stream_mapper_dialog import UsgsStreamMapperDialog
+from pathlib import Path
 import os.path
 # Import for layer coloring
 from PyQt5.QtGui import QColor
@@ -210,8 +211,8 @@ class UsgsStreamMapper:
     def base_station_url(station_id):
         """Return USGS stations prepended with NLDI service end point"""
         return (
-            'https://labs.waterdata.usgs.gov/api/nldi/linked-data'
-            + f'/nwissite/USGS-{station_id}'
+            Path('https://labs.waterdata.usgs.gov/api/nldi/linked-data'
+            + f'/nwissite/USGS-{station_id}')
         )
     
     @staticmethod
@@ -233,7 +234,7 @@ class UsgsStreamMapper:
 
         try:
             suffix = suffix_map[navigation_type]
-            return os.path.join(base_station_url, suffix)
+            return ( base_station_url / suffix ).as_posix()
 
         except KeyError:
             raise KeyError(


### PR DESCRIPTION
- Bump version to 0.2
- Fix issue with mapping base urls to suffix urls in windows previously using `os.path`, now instead using `Path` and `.as_posix()` method.