### PR TITLE
Display error message when layer fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [0.3] - 2022-09-11
+### Fixed
+- display error message when layer fails to load (#3).
+- bring widget to focus if already on screen and try to launch with icon.
+- layer is not added if icon button is pressed repeatedly.

--- a/usgs_stream_mapper/metadata.txt
+++ b/usgs_stream_mapper/metadata.txt
@@ -4,7 +4,7 @@ qgisMinimumVersion=3.0
 description=Display upstream/downstream tributaries and basins using USGS NWIS site numbers
 version=0.2
 author=Austin Raney
-email=aaraney@crimson.ua.edu
+email=aaraney@protonmail.com
 
 about=Quickly display basins and channel flow lines for streams within the NHD network using a USGS NWIS site numbers. All that is needed is a USGS site number and a way to traverse to network.<br>This is a wrapper for the <a href="https://labs.waterdata.usgs.gov/about-nldi/">Hydro-Network Linked Data Index API</a>.
 tags=python, usgs, river, water, flooding, hydrology

--- a/usgs_stream_mapper/metadata.txt
+++ b/usgs_stream_mapper/metadata.txt
@@ -2,7 +2,7 @@
 name=USGS Stream Mapper
 qgisMinimumVersion=3.0
 description=Display upstream/downstream tributaries and basins using USGS NWIS site numbers
-version=0.2
+version=0.3
 author=Austin Raney
 email=aaraney@protonmail.com
 

--- a/usgs_stream_mapper/usgs_stream_mapper.py
+++ b/usgs_stream_mapper/usgs_stream_mapper.py
@@ -37,7 +37,6 @@ from qgis.PyQt.QtWidgets import QAction
 from .resources import *
 # Import the code for the dialog
 from .usgs_stream_mapper_dialog import UsgsStreamMapperDialog
-from pathlib import Path
 import os.path
 # Import for layer coloring
 from PyQt5.QtGui import QColor
@@ -210,11 +209,8 @@ class UsgsStreamMapper:
     @staticmethod
     def base_station_url(station_id):
         """Return USGS stations prepended with NLDI service end point"""
-        return (
-            Path('https://labs.waterdata.usgs.gov/api/nldi/linked-data'
-            + f'/nwissite/USGS-{station_id}')
-        )
-    
+        return f'https://labs.waterdata.usgs.gov/api/nldi/linked-data/nwissite/USGS-{station_id}'
+
     @staticmethod
     def navigate(base_station_url, navigation_type):
         """Map a navigation type to a given base url
@@ -234,7 +230,7 @@ class UsgsStreamMapper:
 
         try:
             suffix = suffix_map[navigation_type]
-            return ( base_station_url / suffix ).as_posix()
+            return f"{base_station_url.rstrip('/')}/{suffix}"
 
         except KeyError:
             raise KeyError(

--- a/usgs_stream_mapper/usgs_stream_mapper.py
+++ b/usgs_stream_mapper/usgs_stream_mapper.py
@@ -248,6 +248,11 @@ class UsgsStreamMapper:
             self.first_start = False
             self.dlg = UsgsStreamMapperDialog()
 
+        # bring widget to focus if already on screen
+        if self.dlg.isVisible():
+            self.dlg.raise_()
+            return
+
         # show the dialog
         self.dlg.show()
         # Run the dialog event loop

--- a/usgs_stream_mapper/usgs_stream_mapper.py
+++ b/usgs_stream_mapper/usgs_stream_mapper.py
@@ -22,6 +22,7 @@
  ***************************************************************************/
 """
 from qgis.core import (
+    Qgis,
     QgsProject,
     QgsVectorLayer,
     )
@@ -264,6 +265,14 @@ class UsgsStreamMapper:
             # Load layer into QGIS
             usgs_layer = QgsVectorLayer(layer_url, f'{site_number}: {navigation_type}')
 
+            if not usgs_layer.isValid():
+                error_subject = "Error"
+                error_message = (f"Failed to load layer data for USGS NWIS site {site_number!r}. "
+                                 f"Verify {site_number!r} is a valid USGS NWIS site and you "
+                                 "have an internet connection.")
+                self.iface.messageBar().pushMessage(error_subject, error_message, level=Qgis.Critical)
+                return
+
             # Add layer styling
             if navigation_type == 'basin':
                 usgs_layer.renderer().symbol().setColor(QColor('green'))
@@ -273,5 +282,4 @@ class UsgsStreamMapper:
                 usgs_layer.renderer().symbol().setWidth(0.5)
 
             # Add layer to map
-            if usgs_layer.isValid():
-                QgsProject.instance().addMapLayer(usgs_layer)
+            QgsProject.instance().addMapLayer(usgs_layer)


### PR DESCRIPTION
### Fixed
- display error message when layer fails to load (#3).
- bring widget to focus if already on screen and try to launch with icon.
- layer is not added if icon button is pressed repeatedly.

fixes #3