### PR TITLE
fix: update nldi url from labs.waterdata.usgs.gov to api.water.usgs.gov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4] - 2025-04-08
+### Changes
+- updated nldi url from labs.waterdata.usgs.gov to api.water.usgs.gov.
+  learn more at https://waterdata.usgs.gov/blog/nldi-intro/#introduction.
+  thanks to Martin for reporting this!
+
 ## [0.3] - 2022-09-11
 ### Fixed
 - display error message when layer fails to load (#3).

--- a/usgs_stream_mapper/metadata.txt
+++ b/usgs_stream_mapper/metadata.txt
@@ -2,7 +2,7 @@
 name=USGS Stream Mapper
 qgisMinimumVersion=3.0
 description=Display upstream/downstream tributaries and basins using USGS NWIS site numbers
-version=0.3
+version=0.4
 author=Austin Raney
 email=aaraney@protonmail.com
 

--- a/usgs_stream_mapper/usgs_stream_mapper.py
+++ b/usgs_stream_mapper/usgs_stream_mapper.py
@@ -210,7 +210,7 @@ class UsgsStreamMapper:
     @staticmethod
     def base_station_url(station_id):
         """Return USGS stations prepended with NLDI service end point"""
-        return f'https://labs.waterdata.usgs.gov/api/nldi/linked-data/nwissite/USGS-{station_id}'
+        return f'https://api.water.usgs.gov/nldi/linked-data/nwissite/USGS-{station_id}'
 
     @staticmethod
     def navigate(base_station_url, navigation_type):


### PR DESCRIPTION
Learn more at https://waterdata.usgs.gov/blog/nldi-intro/#introduction.
Thanks to Martin for reporting this!